### PR TITLE
fix(readme): fix coveralls badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > 雑多Botです。変な機能ばかり実装しています。
 
 <!-- badge urls -->
-[Coveralls Icon]: https://coveralls.io/repos/github/brokenManager/shun-discord-bot/badge.svg?branch=master
-[Coveralls Href]: https://coveralls.io/github/brokenManager/shun-discord-bot?branch=master
+[Coveralls Icon]: https://coveralls.io/repos/github/brokenManager/shun-discord-bot/badge.svg?branch=refs/heads/master
+[Coveralls Href]: https://coveralls.io/github/brokenManager/shun-discord-bot?branch=refs/heads/master
 [Actions Icon]: https://github.com/brokenManager/shun-discord-bot/workflows/Workflows/badge.svg?branch=master
 [Actions Href]: https://github.com/brokenManager/shun-discord-bot/actions?query=branch:master


### PR DESCRIPTION
## 概要

[![Actions Status][Actions Icon]][Actions Href] [![Coverage Status][Coveralls Icon]][Coveralls Href]

README.mdのバッチのURLを修正

<!-- バッジのURL -->
[Coveralls Icon]: https://coveralls.io/repos/github/brokenManager/shun-discord-bot/badge.svg?branch=refs/heads/feature/fix_readme
[Coveralls Href]: https://coveralls.io/github/brokenManager/shun-discord-bot?branch=refs/heads/feature/fix_readme
[Actions Icon]: https://github.com/brokenManager/shun-discord-bot/workflows/Workflows/badge.svg?branch=feature/fix_readme
[Actions Href]: https://github.com/brokenManager/shun-discord-bot/actions?query=branch:feature/fix_readme
