### PR TITLE
feat(main): add more possible typo of "grass"

### DIFF
--- a/computes/main/src/grass/index.ts
+++ b/computes/main/src/grass/index.ts
@@ -8,7 +8,7 @@ import { MessageAttachment } from "discord.js"
 Message.add(async (message) => {
   if (message.author.bot) return
   const id = message.author.id
-  if (!message.content.match(/(草|くさ|kusa)/iu)) return
+  if (!message.content.match(/(草|くさ|kusa|区s|ｋさ|grass|kスア)/iu)) return
   const grass = await database.getGrass(id)
   if (!grass) return
   const count = grass[grass.target]


### PR DESCRIPTION
## 概要

[![Actions Status][Actions Icon]][Actions Href] [![Coverage Status][Coveralls Icon]][Coveralls Href]

<!-- 変更点について簡潔に述べる -->
考えられる「草」のタイポを実装した。

## 詳細
<!-- 詳細を書く 箇条書きでもよい -->
以下を追加した:
- `区s`
- `ｋさ`
- `grass`
- `ｋスア`



<!-- バッジのURL -->
[Coveralls Icon]: https://coveralls.io/repos/github/loxygenK/shun-discord-bot/badge.svg?branch=refs/heads/more-sensitive-grass
[Coveralls Href]: https://coveralls.io/github/loxygenK/shun-discord-bot?branch=refs/heads/more-sensitive-grass
[Actions Icon]: https://github.com/loxygenK/shun-discord-bot/workflows/Workflows/badge.svg?branch=more-sensitive-grass
[Actions Href]: https://github.com/loxygenK/shun-discord-bot/actions?query=branch:more-sensitive-grass